### PR TITLE
Rollback multipart/form-data check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-- Check existence of `multipart/form-data` in `Content-Type`.
+- Fix check of `multipart/form-data` in `Content-Type`.
 
 ## v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- Check existence of `multipart/form-data` in `Content-Type`.
+
 ## v1.1.0
 
 ### Added

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -66,7 +66,7 @@ class RequestParser
             } elseif ('application/x-www-form-urlencoded' === $contentType) {
                 /** @var array<string, mixed> $bodyParams */
                 $bodyParams = $request->post();
-            } elseif ('multipart/form-data' === $contentType) {
+            } elseif (false !== stripos($contentType, 'multipart/form-data')) {
                 $bodyParams = $this->inlineFiles($request);
             } else {
                 throw new RequestError('Unexpected content type: ' . Utils::printSafeJson($contentType));


### PR DESCRIPTION
I'm getting an error when I send the request since Chrome also sends `boundary` in the same `Content-Type` header.

- [ ] Added automated tests
- [ ] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This rollbacks back to the previous version to check if the text contains `multipart/form-data`.

**Breaking changes**

None.

![CleanShot 2021-12-29 at 12 27 05](https://user-images.githubusercontent.com/1166143/147692492-38d290e3-bfaf-4178-82d7-31841e9e989f.png)