### PR TITLE
Added support for version `^2` of `thecodingmachine/safe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## v1.2.1
 
-### Changed
+### Added
 
-- Added support for `^2.0` of `thecodingmachine/safe`
+- Added support for version `^2` of `thecodingmachine/safe`
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## v1.2.1
+
+### Changed
+
+- Added support for `^2.0` of `thecodingmachine/safe`
+
 ## v1.1.1
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": "^7.2 || ^8",
     "illuminate/contracts": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
     "illuminate/http": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
-    "thecodingmachine/safe": "^1.1 || ^2.0",
+    "thecodingmachine/safe": "^1.1 || ^2",
     "webonyx/graphql-php": "^0.13.2 || ^14"
   },
   "require-dev": {
@@ -30,7 +30,7 @@
     "phpstan/extension-installer": "^1",
     "phpstan/phpstan": "^1",
     "phpstan/phpstan-deprecation-rules": "^1",
-    "phpstan/phpstan-phpunit": "^1.0",
+    "phpstan/phpstan-phpunit": "^1",
     "phpstan/phpstan-strict-rules": "^1",
     "phpunit/phpunit": "^7.5 || ^8.5 || ^9",
     "thecodingmachine/phpstan-safe-rule": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": "^7.2 || ^8",
     "illuminate/contracts": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
     "illuminate/http": "5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8",
-    "thecodingmachine/safe": "^1.1",
+    "thecodingmachine/safe": "^1.1 || ^2.0",
     "webonyx/graphql-php": "^0.13.2 || ^14"
   },
   "require-dev": {


### PR DESCRIPTION
Hi there!

This is just a dependency bump to allow the usage of `thecodingmachine/safe:^2.0` with this package. Support for v1 is still included, and in fact required at the moment due to certain dev dependencies in this project not yet supporting v2.

Kind Regards,
Luke
