### PR TITLE
Rely on `$request->input()` instead of manually json decoding request body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.phpunit.result.cache
 /.php-cs-fixer.cache
 /composer.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.phpunit.result.cache
 /.php-cs-fixer.cache
 /composer.lock
-.idea
+/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Rely on $request->input() instead of manually json decoding request body https://github.com/laragraph/utils/pull/12
+- Rely on `$request->input()` instead of manually json decoding request body https://github.com/laragraph/utils/pull/12
 
 ## v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Rely on $request->input() instead of manually json decoding request body https://github.com/laragraph/utils/pull/12
+
 ## v1.6.0
 
 ### Added

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -3,8 +3,6 @@
 namespace Laragraph\Utils;
 
 use GraphQL\Server\Helper;
-use GraphQL\Server\OperationParams;
-use GraphQL\Server\RequestError;
 use GraphQL\Utils\Utils;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -30,10 +28,10 @@ class RequestParser
     /**
      * Converts an incoming HTTP request to one or more OperationParams.
      *
-     * @throws RequestError
-     * @throws BadRequestGraphQLException
+     * @throws \GraphQL\Server\RequestError
+     * @throws \GraphQL\Server\BadRequestGraphQLException
      *
-     * @return OperationParams|array<int, OperationParams>
+     * @return \GraphQL\Server\OperationParams|array<int, \GraphQL\Server\OperationParams>
      */
     public function parseRequest(Request $request)
     {

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -103,10 +103,7 @@ class RequestParser
         }
 
         if (Str::startsWith($contentType, 'application/graphql')) {
-            $content = $request->getContent();
-            assert(is_string($content));
-
-            return ['query' => $content];
+            return ['query' => $request->getContent()];
         }
 
         if ($request->isJson()) {

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -29,7 +29,7 @@ class RequestParser
      * Converts an incoming HTTP request to one or more OperationParams.
      *
      * @throws \GraphQL\Server\RequestError
-     * @throws \GraphQL\Server\BadRequestGraphQLException
+     * @throws \Laragraph\Utils\BadRequestGraphQLException
      *
      * @return \GraphQL\Server\OperationParams|array<int, \GraphQL\Server\OperationParams>
      */

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -5,6 +5,7 @@ namespace Laragraph\Utils;
 use GraphQL\Server\Helper;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\RequestError;
+use GraphQL\Utils\Utils;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -117,6 +118,12 @@ class RequestParser
             return ['query' => $content];
         }
 
-        throw new BadRequestGraphQLException('Could not parse GraphQL request body');
+        if ($request->isJson()) {
+            throw new BadRequestGraphQLException(
+                'GraphQL Server expects JSON object or array, but got: ' . $request->getContent()
+            );
+        }
+
+        throw new BadRequestGraphQLException('Unexpected content type: ' . Utils::printSafeJson($contentType));
     }
 }

--- a/tests/Unit/RequestParserTest.php
+++ b/tests/Unit/RequestParserTest.php
@@ -136,6 +136,7 @@ final class RequestParserTest extends TestCase
         $parser = new RequestParser();
 
         $this->expectException(BadRequestGraphQLException::class);
+        $this->expectExceptionMessage('Unexpected content type: "' . $contentType . '"');
         $parser->parseRequest($request);
     }
 
@@ -148,7 +149,6 @@ final class RequestParserTest extends TestCase
         yield ['application/foobar'];
         yield ['application/josn'];
         yield ['application/grapql'];
-        yield ['application/foo;charset=application/json'];
     }
 
     public function testNoQuery(): void
@@ -172,6 +172,8 @@ final class RequestParserTest extends TestCase
         $parser = new RequestParser();
 
         $this->expectException(BadRequestGraphQLException::class);
+        $this->expectExceptionMessage('GraphQL Server expects JSON object or array, but got: this is not valid json');
+
         $parser->parseRequest($request);
     }
 
@@ -187,6 +189,8 @@ final class RequestParserTest extends TestCase
         $parser = new RequestParser();
 
         $this->expectException(BadRequestGraphQLException::class);
+        $this->expectExceptionMessage('GraphQL Server expects JSON object or array, but got: "this should be a map with query, variables, etc."');
+
         $parser->parseRequest($request);
     }
 


### PR DESCRIPTION
- [x] Added automated tests (All existing unit tests cover well each cases)
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

With this changes, on Laravel projects using Http middleware that manipulate the request payload (such as `Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull`, `Illuminate\Foundation\Http\Middleware\TrimStrings` or `Illuminate\Foundation\Http\Middleware\TransformsRequest`) will now work as expected. This is the primary goal of this pull request.

**Breaking changes**

Having middleware in place than suddenly taking effect, can introduce breaking changes on your project. Make sure you adjust your middleware & middlewareGroups in your `app/http/kernel.php` according to your needs.