### PR TITLE
tests: make dataprovider static & some

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           coverage: none
           extensions: mbstring
-          php-version: 8.1
+          php-version: 8.3
 
       - run: composer install --no-interaction --no-progress --no-suggest
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
 
       - name: "Install locked dependencies with composer"
         run: composer install --no-interaction --no-progress
@@ -144,7 +144,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: pcov
-          php-version: 8.1
+          php-version: 8.3
 
       - name: "Install locked dependencies with composer"
         run: composer install --no-interaction --no-progress

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,9 +14,6 @@ parameters:
   - message: "#Method .* throws checked exception .* but it's missing from the PHPDoc @throws tag.#"
     paths:
     - tests/*
-  - message: "#@dataProvider .* related method must be static in PHPUnit 10 and newer.#"
-    paths:
-    - tests/*
   # Install https://plugins.jetbrains.com/plugin/7677-awesome-console to make those links clickable
   editorUrl: '%%relFile%%:%%line%%'
   editorUrlTitle: '%%relFile%%:%%line%%'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+        cacheDirectory=".phpunit.result.cache"
 >
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/Unit/RequestParserTest.php
+++ b/tests/Unit/RequestParserTest.php
@@ -46,7 +46,7 @@ final class RequestParserTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function jsonLikeContentTypes(): iterable
+    public static function jsonLikeContentTypes(): iterable
     {
         yield ['application/json'];
         yield ['application/graphql+json'];
@@ -75,7 +75,7 @@ final class RequestParserTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function graphQLContentTypes(): iterable
+    public static function graphQLContentTypes(): iterable
     {
         yield ['application/graphql'];
         yield ['application/graphql;charset=UTF-8'];
@@ -103,7 +103,7 @@ final class RequestParserTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function formContentTypes(): iterable
+    public static function formContentTypes(): iterable
     {
         yield ['application/x-www-form-urlencoded'];
         yield ['application/x-www-form-urlencoded;bla;blub'];
@@ -166,7 +166,7 @@ final class RequestParserTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function nonsensicalContentTypes(): iterable
+    public static function nonsensicalContentTypes(): iterable
     {
         yield ['foobar'];
         yield ['application/foobar'];
@@ -263,7 +263,7 @@ final class RequestParserTest extends TestCase
     /**
      * @return iterable<array{string}>
      */
-    public function multipartFormContentTypes(): iterable
+    public static function multipartFormContentTypes(): iterable
     {
         yield ['multipart/form-data'];
         yield ['multipart/form-data; boundary=----WebkitFormBoundaryasodfh98ho1hfdsdfadfNX'];


### PR DESCRIPTION
## Summary
In https://github.com/laragraph/utils/pull/16 I wrote
> phpunit 10 throws a warning for non-static dataproviders
>  Fixing them wasn't as straightforward, as they're calling non-static methods also into the framework; therefore I left this for now as it's only warning (needs to be fixed for phpunit 11)

Turns out I was partially wrong, the providers are fairly basic and just be switched to static.

Additional changes:
- migrate phpunit config for latest version
  Note: older version will see unsupported XML attributes and report it, it does not impact the functionality of the tests 
  ![image](https://github.com/laragraph/utils/assets/87493/bd114c5e-ce0e-4a51-9264-f211ddc673d1)
  
  It also does not impact code coverage _per se_, as it will use latest phpunit only
- chore: use latest PHP version in GHA where possible