### PR TITLE
Ignore query parameters in non-GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support Laravel 13 https://github.com/laragraph/utils/pull/22
+- Fixes error when using GET parameters on batched queries https://github.com/laragraph/utils/issues/26
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v2.3.1
+
+### Fixed
+
+- Ignore query parameters in non-GET requests https://github.com/laragraph/utils/issues/26
+
 ## v2.3.0
 
 ### Added
 
 - Support Laravel 13 https://github.com/laragraph/utils/pull/22
-- Fixes error when using GET parameters on batched queries https://github.com/laragraph/utils/issues/26
 
 ## v2.2.0
 

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -63,7 +63,7 @@ class RequestParser
             return ['query' => $request->getContent()];
         }
 
-        $bodyParams = $request->input();
+        $bodyParams = $request->post();
 
         if (is_array($bodyParams) && count($bodyParams) > 0) {
             if (Arr::isAssoc($bodyParams)) {

--- a/tests/Unit/RequestParserTest.php
+++ b/tests/Unit/RequestParserTest.php
@@ -525,7 +525,7 @@ final class RequestParserTest extends TestCase
      * @param  array<mixed>  $headers
      * @param  string|resource|null  $content
      */
-    private function makeRequest(string $method, array $parameters = [], array $files = [], array $headers = [], $content = null, $uri = 'http://foo.bar/graphql'): Request
+    private function makeRequest(string $method, array $parameters = [], array $files = [], array $headers = [], $content = null, string $uri = 'http://foo.bar/graphql'): Request
     {
         $symfonyRequest = SymfonyRequest::create(
             $uri,

--- a/tests/Unit/RequestParserTest.php
+++ b/tests/Unit/RequestParserTest.php
@@ -119,6 +119,29 @@ final class RequestParserTest extends TestCase
         self::assertSame($barQuery, $barParams->query);
     }
 
+    public function testPostWithBatchedRequestAndGetParams(): void
+    {
+        $fooQuery = /** @lang GraphQL */ '{ foo }';
+        $barQuery = /** @lang GraphQL */ '{ bar }';
+        $request = $this->makeRequest(
+            'POST',
+            [],
+            [],
+            ['Content-Type' => 'application/json'],
+            \Safe\json_encode([
+                ['query' => $fooQuery],
+                ['query' => $barQuery],
+            ]),
+            'http://foo.bar/graphql?Operation=foo,bar'
+        );
+        $params = (new RequestParser())->parseRequest($request);
+
+        self::assertIsArray($params);
+        [$fooParams, $barParams] = $params;
+        self::assertSame($fooQuery, $fooParams->query);
+        self::assertSame($barQuery, $barParams->query);
+    }
+
     public function testPostDefaultsToRegularForm(): void
     {
         $query = /** @lang GraphQL */ '{ foo }';
@@ -502,10 +525,10 @@ final class RequestParserTest extends TestCase
      * @param  array<mixed>  $headers
      * @param  string|resource|null  $content
      */
-    private function makeRequest(string $method, array $parameters = [], array $files = [], array $headers = [], $content = null): Request
+    private function makeRequest(string $method, array $parameters = [], array $files = [], array $headers = [], $content = null, $uri = 'http://foo.bar/graphql'): Request
     {
         $symfonyRequest = SymfonyRequest::create(
-            'http://foo.bar/graphql',
+            $uri,
             $method,
             $parameters,
             [],


### PR DESCRIPTION
- [X] Added automated tests
- [X] Documented for all relevant versions
- [X] Updated the changelog

Resolves #24 

**Changes**

$bodyParameters will no longer contain GET parameters on POST requests
